### PR TITLE
feat(movie-details): fetch single movie details and update interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@tanstack/react-query": "^5.89.0",
         "next": "15.5.3",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5084,6 +5085,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@tanstack/react-query": "^5.89.0",
     "next": "15.5.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,0 +1,234 @@
+// "use client";
+
+// import { useParams } from "next/navigation";
+// import Image from "next/image";
+// import Link from "next/link";
+// import { useMovieDetails } from "@/hooks/useMovies";
+// import Loader from "@/components/Loader";
+
+// export default function MovieDetailsPage() {
+//   const { id } = useParams<{ id: string }>();
+//   const { data: movie, isLoading, isError } = useMovieDetails(id);
+
+//   if (isLoading) return <Loader />;
+//   if (isError || !movie) return <p className="text-red-500">Failed to load movie details.</p>;
+
+//   return (
+//     <div className="container mx-auto p-4">
+//       {/* Back Button */}
+//       <Link href="/" className="text-blue-600 hover:underline mb-4 block">
+//         ← Back to Movies
+//       </Link>
+
+//       {/* Top Section */}
+//       <div className="flex flex-col md:flex-row gap-6">
+//         <Image
+//           src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+//           alt={movie.title}
+//           width={300}
+//           height={450}
+//           className="rounded-lg shadow-md"
+//         />
+
+//         <div>
+//           <h1 className="text-3xl font-bold">{movie.title}</h1>
+//           <p className="text-gray-500">
+//             ⭐ {movie.vote_average.toFixed(1)} / 10 ({movie.vote_count} votes) •{" "}
+//             {movie.release_date} • {movie.runtime} mins
+//           </p>
+
+//           <div className="flex gap-2 mt-2 flex-wrap">
+//             {movie.genres.map((genre) => (
+//               <span
+//                 key={genre.id}
+//                 className="bg-blue-100 text-blue-700 text-sm px-2 py-1 rounded-full"
+//               >
+//                 {genre.name}
+//               </span>
+//             ))}
+//           </div>
+
+//           <h2 className="mt-4 font-semibold text-xl">Overview</h2>
+//           <p className="text-gray-700 mt-2">{movie.overview}</p>
+
+//           {/* Production Companies */}
+//           <h3 className="mt-4 font-semibold">Production Companies</h3>
+//           <div className="flex gap-4 flex-wrap mt-2">
+//             {movie.production_companies.map((company) => (
+//               <div key={company.id} className="flex items-center gap-2">
+//                 {company.logo_path && (
+//                   <Image
+//                     src={`https://image.tmdb.org/t/p/w200${company.logo_path}`}
+//                     alt={company.name}
+//                     width={50}
+//                     height={30}
+//                   />
+//                 )}
+//                 <span>{company.name}</span>
+//               </div>
+//             ))}
+//           </div>
+//         </div>
+//       </div>
+
+//       {/* Cast */}
+//       <h2 className="mt-8 text-2xl font-bold">Cast</h2>
+//       <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-4">
+//         {movie.credits.cast.slice(0, 10).map((actor) => (
+//           <div key={actor.id} className="text-center">
+//             <Image
+//               src={
+//                 actor.profile_path
+//                   ? `https://image.tmdb.org/t/p/w200${actor.profile_path}`
+//                   : "/placeholder.jpg"
+//               }
+//               alt={actor.name}
+//               width={150}
+//               height={200}
+//               className="rounded-lg object-cover mx-auto"
+//             />
+//             <p className="font-semibold mt-2">{actor.name}</p>
+//             <p className="text-sm text-gray-500">{actor.character}</p>
+//           </div>
+//         ))}
+//       </div>
+
+//       {/* Crew */}
+//       <h2 className="mt-8 text-2xl font-bold">Key Crew</h2>
+//       <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-4">
+//         {movie.credits.crew
+//           .filter((crew) =>
+//             ["Director", "Producer", "Screenplay", "Novel"].includes(crew.job)
+//           )
+//           .slice(0, 10)
+//           .map((crew) => (
+//             <div key={crew.id} className="text-center">
+//               <Image
+//                 src={
+//                   crew.profile_path
+//                     ? `https://image.tmdb.org/t/p/w200${crew.profile_path}`
+//                     : "/placeholder.jpg"
+//                 }
+//                 alt={crew.name}
+//                 width={150}
+//                 height={200}
+//                 className="rounded-lg object-cover mx-auto"
+//               />
+//               <p className="font-semibold mt-2">{crew.name}</p>
+//               <p className="text-sm text-gray-500">{crew.job}</p>
+//             </div>
+//           ))}
+//       </div>
+//     </div>
+//   );
+// }
+
+
+"use client";
+
+import { useParams } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import { useMovieDetails } from "@/hooks/useMovies";
+import Loader from "@/components/Loader";
+import PersonCard from "@/components/PersonCard";
+
+export default function MovieDetailsPage() {
+  const { id } = useParams<{ id: string }>();
+  const { data: movie, isLoading, isError } = useMovieDetails(id);
+
+  if (isLoading) return <Loader />;
+  if (isError || !movie) return <p className="text-red-500">Failed to load movie details.</p>;
+
+  return (
+    <div className="container mx-auto p-4">
+      {/* Back Button */}
+      <Link href="/" className="text-blue-600 hover:underline mb-4 block">
+        ← Back to Movies
+      </Link>
+
+      {/* Top Section */}
+      <div className="flex flex-col md:flex-row gap-6">
+        <Image
+          src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+          alt={movie.title}
+          width={300}
+          height={450}
+          className="rounded-lg shadow-md"
+        />
+
+        <div>
+          <h1 className="text-3xl font-bold">{movie.title}</h1>
+          <p className="text-gray-500">
+            ⭐ {movie.vote_average.toFixed(1)} / 10 ({movie.vote_count} votes) •{" "}
+            {movie.release_date} • {movie.runtime} mins
+          </p>
+
+          <div className="flex gap-2 mt-2 flex-wrap">
+            {movie.genres.map((genre) => (
+              <span
+                key={genre.id}
+                className="bg-blue-100 text-blue-700 text-sm px-2 py-1 rounded-full"
+              >
+                {genre.name}
+              </span>
+            ))}
+          </div>
+
+          <h2 className="mt-4 font-semibold text-xl">Overview</h2>
+          <p className="text-gray-700 mt-2">{movie.overview}</p>
+
+          {/* Production Companies */}
+          <h3 className="mt-4 font-semibold">Production Companies</h3>
+          <div className="flex gap-4 flex-wrap mt-2">
+            {movie.production_companies.map((company) => (
+              <div key={company.id} className="flex items-center gap-2">
+                {company.logo_path && (
+                  <Image
+                    src={`https://image.tmdb.org/t/p/w200${company.logo_path}`}
+                    alt={company.name}
+                    width={50}
+                    height={30}
+                  />
+                )}
+                <span>{company.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Cast */}
+      <h2 className="mt-8 text-2xl font-bold">Cast</h2>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-4">
+        {movie.credits.cast.slice(0, 10).map((actor) => (
+          <PersonCard
+            key={actor.id}
+            name={actor.name}
+            role={actor.character}
+            profilePath={actor.profile_path}
+          />
+        ))}
+      </div>
+
+      {/* Crew */}
+      <h2 className="mt-8 text-2xl font-bold">Key Crew</h2>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-4">
+        {movie.credits.crew
+          .filter((crew) =>
+            ["Director", "Producer", "Screenplay", "Novel"].includes(crew.job)
+          )
+          .slice(0, 10)
+          .map((crew) => (
+            <PersonCard
+              key={crew.id}
+              name={crew.name}
+              role={crew.job}
+              profilePath={crew.profile_path}
+            />
+          ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,3 +1,7 @@
+import { HiChevronLeft, HiChevronRight } from "react-icons/hi";
+
+
+
 interface PaginationProps {
   page: number;
   totalPages: number;
@@ -6,21 +10,21 @@ interface PaginationProps {
 
 export default function Pagination({ page, totalPages, setPage }: PaginationProps) {
   return (
-    <div className="flex justify-center items-center gap-4 mt-6">
+    <div className="flex justify-center items-center gap-4 my-6">
       <button
         disabled={page === 1}
         onClick={() => setPage(page - 1)}
-        className="px-3 py-1 rounded bg-gray-200 disabled:opacity-50"
+        className="px-3 py-1 rounded bg-blue-400 disabled:opacity-50 flex"
       >
-        Prev
+        <HiChevronLeft size={24} /> Prev
       </button>
       <span>{page} / {totalPages}</span>
       <button
         disabled={page === totalPages}
         onClick={() => setPage(page + 1)}
-        className="px-3 py-1 rounded bg-gray-200 disabled:opacity-50"
+        className="px-3 py-1 rounded bg-blue-400 disabled:opacity-50 flex"
       >
-        Next
+        Next<HiChevronRight size={24} />
       </button>
     </div>
   );

--- a/src/components/PersonCard.tsx
+++ b/src/components/PersonCard.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image";
+
+interface PersonCardProps {
+  name: string;
+  role: string; // Character (for cast) OR Job (for crew)
+  profilePath: string | null;
+}
+
+export default function PersonCard({ name, role, profilePath }: PersonCardProps) {
+  return (
+    <div className="text-center">
+      <Image
+        src={
+          profilePath
+            ? `https://image.tmdb.org/t/p/w200${profilePath}`
+            : "/placeholder.jpg"
+        }
+        alt={name}
+        width={150}
+        height={200}
+        className="rounded-lg object-cover mx-auto"
+      />
+      <p className="font-semibold mt-2">{name}</p>
+      <p className="text-sm text-gray-500">{role}</p>
+    </div>
+  );
+}

--- a/src/interfaces/movie.ts
+++ b/src/interfaces/movie.ts
@@ -2,9 +2,11 @@ export interface Movie {
   id: number;
   title: string;
   overview: string;
-  poster_path: string;
+  poster_path: string | null;
   release_date: string;
   vote_average: number;
+  vote_count: number; // added
+  runtime: number; // added
 }
 
 export interface MovieListResponse {
@@ -16,8 +18,24 @@ export interface MovieListResponse {
 
 export interface MovieDetails extends Movie {
   genres: { id: number; name: string }[];
+  production_companies: {
+    id: number;
+    logo_path: string | null;
+    name: string;
+    origin_country: string;
+  }[];
   credits: {
-    cast: { id: number; name: string; character: string; profile_path: string }[];
-    crew: { id: number; name: string; job: string }[];
+    cast: {
+      id: number;
+      name: string;
+      character: string;
+      profile_path: string | null; // allow null
+    }[];
+    crew: {
+      id: number;
+      name: string;
+      job: string;
+      profile_path: string | null; // allow null
+    }[];
   };
 }


### PR DESCRIPTION
# PR Description

## What this PR does
- Implements a dynamic movie details page (`/movie/[id]`) to fetch and display a single movie’s information.
- Shows movie poster, title, overview, genres, release date, vote average/count, runtime, production companies, cast, and key crew.

## TypeScript updates
- Updated `MovieDetails` interface to include `vote_count`, `runtime`, and `production_companies`.
- Made `profile_path` nullable for cast and crew to handle missing images.

## Components updated/added
- `MovieDetailsPage` – main page for single movie details.
- `PersonCard` – now handles nullable images for cast and crew.

## Why
- Ensures full type safety with TMDB API response.
- Provides a fully functional and typed movie details page.
- Eliminates TypeScript errors related to missing fields in previous interfaces.
